### PR TITLE
Fix invalid URL on all requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ and https://issues.apache.org/jira/browse/SUREFIRE-1588 -->
 
     <groupId>com.patreon</groupId>
     <artifactId>patreon</artifactId>
-    <version>0.4.2</version>
+    <version>0.4.3</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Interact with the Patreon API via OAuth</description>

--- a/src/main/java/com/patreon/resources/RequestUtil.java
+++ b/src/main/java/com/patreon/resources/RequestUtil.java
@@ -13,7 +13,7 @@ import static com.patreon.PatreonAPI.BASE_URI;
 public class RequestUtil {
 
   public InputStream request(String pathSuffix, String accessToken) throws IOException {
-      String prefix = BASE_URI + "/api/oauth2/api/";
+      String prefix = BASE_URI + "/api/oauth2/api";
       URL url = new URL(prefix.concat(pathSuffix));
       HttpURLConnection connection = (HttpURLConnection) url.openConnection();
       connection.setRequestProperty("Authorization", "Bearer ".concat(accessToken));


### PR DESCRIPTION
This PR fixes an Invalid URL issue that is currently happening on Patreon-Java.

```
java.io.FileNotFoundException: https://www.patreon.com/api/oauth2/api//campaigns/123123/pledges?page%5Bcount%5D=15
    at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1915)
    at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1515)
    at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:251)
    at com.patreon.resources.RequestUtil.request(RequestUtil.java:26)
    at com.patreon.PatreonAPI.getDataStream(PatreonAPI.java:201)
    at com.patreon.PatreonAPI.fetchPageOfPledges(PatreonAPI.java:156)
    at com.patreon.PatreonAPI.fetchPageOfPledges(PatreonAPI.java:129)
    at com.patreon.PatreonAPI.fetchAllPledges(PatreonAPI.java:189)
```

This path issue has been present on Patreon-Java for a long time now but Patreon API never had issues with it, recently however, I started to receive a FileNotFound/404 on the URL because of that extra `/` in there.